### PR TITLE
Adding accets_nested_attributes_for in the documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,11 +22,11 @@ Running the generator will add a file at <tt>public/javascripts/nested_form.js</
 
 == Usage
 
-Imagine you have a +Project+ model that +has_many+ +:tasks+. To be able to use this gem, you'll need to add +accepts_nested_attributes_for+ +:tasks+ to your Project model.
+Imagine you have a <tt>Project</tt> model that <tt>has_many :tasks</tt>. To be able to use this gem, you'll need to add <tt>accepts_nested_attributes_for :tasks</tt> to your Project model.
 
 This will create a <tt>tasks_attributes=</tt> method, so you may need to add it to the <tt>attr_accessible</tt> array. (<tt>attr_accessible :tasks_attributes</tt>)
 
-(If you don't have the +accepts_nested_attributes_for+ +:tasks+ you'll get a Missing Block Error)
+(If you don't have the <tt>accepts_nested_attributes_for :tasks</tt> you'll get a Missing Block Error)
 
 Then use the +nested_form_for+ helper method to enable the nesting.
 


### PR DESCRIPTION
I've mentioned the need of adding accets_nested_attributes_for in the model. It should close #24. I'm not the better writer but I hope it's at least easy to understand :-P  (Obviously, change it if you think it's needed).

Thanks,

Nicolás Hock Isaza
