### PR TITLE
Added block form to link_to_add and link_to_remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.gem
 Gemfile.lock
 .bundle
+.idea

--- a/lib/nested_form/builder.rb
+++ b/lib/nested_form/builder.rb
@@ -1,6 +1,21 @@
 module NestedForm
   class Builder < ::ActionView::Helpers::FormBuilder
-    def link_to_add(name, association)
+    # ==== Signatures
+    #
+    #   link_to_add(content, association)
+    #
+    #   link_to_add(association) do
+    #     # content
+    #   end
+    #
+    def link_to_add(*args, &block)
+      if block_given?
+        content = @template.capture(&block)
+        association = args.first
+      else
+        content = args.first
+        association = args.second
+      end
       @fields ||= {}
       @template.after_nested_form(association) do
         model_object = object.class.reflect_on_association(association).klass.new
@@ -9,11 +24,24 @@ module NestedForm
         output.safe_concat('</div>')
         output
       end
-      @template.link_to(name, "javascript:void(0)", :class => "add_nested_fields", "data-association" => association)
+      @template.link_to(content, "javascript:void(0)", :class => "add_nested_fields", "data-association" => association)
     end
 
-    def link_to_remove(name)
-      hidden_field(:_destroy) + @template.link_to(name, "javascript:void(0)", :class => "remove_nested_fields")
+    # ==== Signatures
+    #
+    #   link_to_remove(content)
+    #
+    #   link_to_add do
+    #     # content
+    #   end
+    #
+    def link_to_remove(*args, &block)
+      if block_given?
+        content = @template.capture(&block)
+      else
+        content = args.first
+      end
+      hidden_field(:_destroy) + @template.link_to(content, "javascript:void(0)", :class => "remove_nested_fields")
     end
 
     def fields_for_with_nested_attributes(association_name, args, block)

--- a/spec/nested_form/builder_spec.rb
+++ b/spec/nested_form/builder_spec.rb
@@ -12,9 +12,17 @@ describe NestedForm::Builder do
     it "should have an add link" do
       @builder.link_to_add("Add", :tasks).should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks">Add</a>'
     end
+    
+    it "add link should accept a block" do
+      @builder.link_to_add(:tasks){"Add"}.should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks">Add</a>'
+    end
 
     it "should have a remove link" do
       @builder.link_to_remove("Remove").should == '<input id="item__destroy" name="item[_destroy]" type="hidden" value="false" /><a href="javascript:void(0)" class="remove_nested_fields">Remove</a>'
+    end
+
+    it "remove link accepts a block" do
+      @builder.link_to_remove{"Remove"}.should == '<input id="item__destroy" name="item[_destroy]" type="hidden" value="false" /><a href="javascript:void(0)" class="remove_nested_fields">Remove</a>'
     end
 
     it "should wrap nested fields each in a div with class" do


### PR DESCRIPTION
I added support for the block form of the methods "link_to_add" and "link_to_remove" which helps make them a little more like 'link_to' and allows for more flexible HTML markup around the links.  I also added specs to test the block form and included a brief rdoc comment to demonstrate both signatures.
