### PR TITLE
Uses length validation to hide add link when you reach maximum # of nested objects

### DIFF
--- a/lib/generators/nested_form/templates/jquery_nested_form.js
+++ b/lib/generators/nested_form/templates/jquery_nested_form.js
@@ -35,6 +35,7 @@ jQuery(function($) {
     content     = content.replace(regexp, "new_" + new_id);
 
     var field = $(content).insertBefore(this);
+    check_maximum();
     $(this).closest("form").trigger({type: 'nested:fieldAdded', field: field});
     return false;
   });
@@ -45,7 +46,18 @@ jQuery(function($) {
       hidden_field.value = '1';
     }
     $(this).closest('.fields').hide();
+    check_maximum();
     $(this).closest("form").trigger('nested:fieldRemoved');
     return false;
   });
+  
+  function check_maximum() {
+    $('form a.add_nested_fields').each(function(){
+      var assoc   = $(this).attr('data-association');            // Name of child
+      var maximum = $(this).attr('data-maximum');                // Maximum # of children
+      $('.' + assoc+':visible').length >= maximum ? $(this).hide() : $(this).show();
+    });
+  }
+  
+  check_maximum();
 });

--- a/lib/nested_form/builder.rb
+++ b/lib/nested_form/builder.rb
@@ -16,6 +16,14 @@ module NestedForm
       association = args.pop
       options[:class] = [options[:class], "add_nested_fields"].compact.join(" ")
       options["data-association"] = association
+      validators = self.object.class.validators_on(association)
+      unless validators.empty?
+        length_validator = validators.select {|item| item.class == ActiveModel::Validations::LengthValidator}.first
+        unless length_validator.nil?
+          maximum = length_validator.options[:maximum]
+          options["data-maximum"] = maximum
+        end
+      end
       args << (options.delete(:href) || "javascript:void(0)")
       args << options
       @fields ||= {}
@@ -57,7 +65,7 @@ module NestedForm
     end
 
     def fields_for_nested_model(name, object, options, block)
-      output = '<div class="fields">'.html_safe
+      output = "<div class=\"fields #{object.class.name.underscore.pluralize}\">".html_safe
       output << super
       output.safe_concat('</div>')
       output


### PR DESCRIPTION
Hides the add link when reaches maximum number of nested objects as defined in length validation. Ie.

``` ruby
class Project < ActiveRecord::Base
  has_many :tasks
  validates :tasks, :length => { :in => 1..3 }
end
```

Adds the attribute 'data-maximum' to the link and checks this against the number of visible nested entries on both add and remove and also on page load.

Have changed jQuery template only as am not familiar with Prototype. Probably should be altered to bind to the 'nested:fieldAdded' and 'nested:fieldRemoved' triggers.

Hope this is useful.
