### PR TITLE
hiding more

### DIFF
--- a/lib/generators/nested_form/templates/prototype_nested_form.js
+++ b/lib/generators/nested_form/templates/prototype_nested_form.js
@@ -45,7 +45,7 @@ document.observe('click', function(e, el) {
 		if(hidden_field) {
 		  hidden_field.value = '1';
 		}
-		el.ancestors()[1].hide();
+                el.up('.fields').hide();
 		return false;
 	}
 });


### PR DESCRIPTION
when removing fields we must hide `ancestors()[1]` which is the `<div.fields>`
hiding `ancestors()[0]` keeps `remove label` unhidden!
