### PR TITLE
Fix wrong associated deep nested child and hiding all model fields.

### DIFF
--- a/lib/generators/nested_form/templates/prototype_nested_form.js
+++ b/lib/generators/nested_form/templates/prototype_nested_form.js
@@ -6,7 +6,7 @@ document.observe('click', function(e, el) {
 
 	  // Make the context correct by replacing new_<parents> with the generated ID
 	  // of each of the parent objects
-	  var context = (el.getOffsetParent('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+	  var context = (el.up('.fields') ? el.up('.fields').down('input').readAttribute('name') : '').replace(new RegExp('\[[a-z]+\]$'), '');
 
 	  // context will be something like this for a brand new form:
 	  // project[tasks_attributes][new_1255929127459][assignments_attributes][new_1255929128105]
@@ -45,7 +45,7 @@ document.observe('click', function(e, el) {
 		if(hidden_field) {
 		  hidden_field.value = '1';
 		}
-		el.ancestors()[0].hide();
+		el.up('.fields').hide();
 		return false;
 	}
 });


### PR DESCRIPTION
Hi Ryan!
I have a deep nested form where:

```
Page has_many :articles
Article has_many :pictures
```

For this site I have to use prototype. When I´m editing a page with 2 existing articles, and add a picture to the second article, I got wrong input names. The name was the same as for the first article_picture.
`page[articles_attributes][0][pictures_attributes][new_1308310344282][bild]
page[articles_attributes][0][pictures_attributes][new_1308310344282][bild]`
This causes, the picture is going to be associated to the first article instead of the second.

I changed your prototype template to fix this. I think it´s also more like the jQuery version. Now I get correct names and the picture is associated correctly:
`page[articles_attributes][0][pictures_attributes][new_1308310344282][bild]
page[articles_attributes][1][pictures_attributes][new_1308310344282][bild]`

I have also include my change for [this issue](https://github.com/ryanb/nested_form/pull/52)

PS.: Many thanks for your great railscasts!!!
