### PR TITLE
Make the fields positionable, before, after, ... a given node (fix Issue #66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .bundle
 log
 gemfiles
+/.idea/

--- a/lib/generators/nested_form/templates/jquery_nested_form.js
+++ b/lib/generators/nested_form/templates/jquery_nested_form.js
@@ -4,6 +4,9 @@ jQuery(function($) {
     var assoc   = $(this).attr('data-association');            // Name of child
     var content = $('#' + assoc + '_fields_blueprint').html(); // Fields template
 
+    var insert_node   = $(this).attr('data-insert-node') || this;            // Insertion Node
+    var insert_position   = $(this).attr('data-insert-position') || 'before';            // Insertion Position
+
     // Make the context correct by replacing new_<parents> with the generated ID
     // of each of the parent objects
     var context = ($(this).closest('.fields').find('input:first').attr('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
@@ -34,7 +37,26 @@ jQuery(function($) {
     var new_id  = new Date().getTime();
     content     = content.replace(regexp, "new_" + new_id);
 
-    var field = $(content).insertBefore(this);
+
+    insert_node = $(this).closest("form").find(insert_node);
+//    var field = $(content).insertBefore(this);
+    switch(insert_position){
+    case 'before':
+        var field = $(content).insertBefore(insert_node);
+        break;
+    case 'after':
+        var field = $(content).insertAfter(insert_node);
+        break;
+    case 'top':
+        var field = $(content).prependTo(insert_node);
+        break;
+    case 'bottom':
+        var field = $(content).appendTo(insert_node);
+        break;
+    default:
+        var field = $(content).insertBefore(this);
+    }
+
     $(this).closest("form").trigger({type: 'nested:fieldAdded', field: field});
     return false;
   });

--- a/lib/generators/nested_form/templates/prototype_nested_form.js
+++ b/lib/generators/nested_form/templates/prototype_nested_form.js
@@ -4,6 +4,9 @@ document.observe('click', function(e, el) {
 	  var assoc   = el.readAttribute('data-association');           // Name of child
 	  var content = $(assoc + '_fields_blueprint').innerHTML; // Fields template
 
+      var insert_node   = el.readAttribute('data-insert-node') || el;            // Insertion Node
+      var insert_position   = el.readAttribute('data-insert-position') || 'before';            // Insertion Position
+
 	  // Make the context correct by replacing new_<parents> with the generated ID
 	  // of each of the parent objects
 	  var context = (el.getOffsetParent('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
@@ -34,7 +37,8 @@ document.observe('click', function(e, el) {
 	  var new_id  = new Date().getTime();
 	  content     = content.replace(regexp, "new_" + new_id);
 
-	  el.insert({ before: content });
+      if (Object.isString(insert_node)) insert_node = e.findElement('form '+insert_node)
+	  insert_node.insert({ insert_position: content });
 	  return false;
 	}
 });

--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -16,6 +16,10 @@ module NestedForm
       association = args.pop
       options[:class] = [options[:class], "add_nested_fields"].compact.join(" ")
       options["data-association"] = association
+
+      options["data-insert-node"] = options.delete(:node)
+      options["data-insert-position"] = options.delete(:position)
+
       args << (options.delete(:href) || "javascript:void(0)")
       args << options
       @fields ||= {}

--- a/nested_form.gemspec
+++ b/nested_form.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec-rails", "~> 2.6.0"
   s.add_development_dependency "mocha"
-  # s.add_development_dependency "rails", "~> 3.1.0.rc"
+  s.add_development_dependency "rails", "~> 3.0.8"
 
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"

--- a/spec/nested_form/builder_spec.rb
+++ b/spec/nested_form/builder_spec.rb
@@ -16,6 +16,12 @@ require "spec_helper"
         @builder.link_to_add(:tasks) { "Add" }.should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks">Add</a>'
       end
 
+      it "has an add link with positionable attributes" do
+        @builder.link_to_add("Add", :tasks, :position => :before).should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks" data-insert-position="before">Add</a>'
+        @builder.link_to_add("Add", :tasks, :node => 'table').should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks" data-insert-node="table">Add</a>'
+        @builder.link_to_add("Add", :tasks, :node => 'table', :position => :before).should == '<a href="javascript:void(0)" class="add_nested_fields" data-association="tasks" data-insert-node="table" data-insert-position="before">Add</a>'
+      end
+
       it "has a remove link which behaves similar to a Rails link_to" do
         @builder.link_to_remove("Remove").should == '<input id="item__destroy" name="item[_destroy]" type="hidden" value="false" /><a href="javascript:void(0)" class="remove_nested_fields">Remove</a>'
         @builder.link_to_remove("Remove", :class => "foo", :href => "url").should == '<input id="item__destroy" name="item[_destroy]" type="hidden" value="false" /><a href="url" class="foo remove_nested_fields">Remove</a>'


### PR DESCRIPTION
Hi (again) Ryan,

Here is my implementation of the positionable feature.
Make the fields positionable, before, after, at the top (prepend) or at the bottom (append) of a given node by adding attributes to the "add" link.

``` ruby
  f.link_to_add("Add", :tasks, :node => 'table', :position => :before)
# OR
  f.link_to_add("Add", :tasks, :node => '.tasks', :position => :top)
```

Fully tested with jQuery (and in use), not tested with Prototype.

EDIT : the choosen node should be unique (or you will get several new set of fields with same id's) and outside of any `.fields` set (or you won't be able to remove the added fieldset)
