### PR TITLE
Move blueprint to window javascript variable (Fix Issue #3)

### DIFF
--- a/lib/generators/nested_form/templates/jquery_nested_form.js
+++ b/lib/generators/nested_form/templates/jquery_nested_form.js
@@ -2,7 +2,7 @@ jQuery(function($) {
   $('form a.add_nested_fields').live('click', function() {
     // Setup
     var assoc   = $(this).attr('data-association');            // Name of child
-    var content = $('#' + assoc + '_fields_blueprint').html(); // Fields template
+    var content = window[assoc+'_fields_blueprint']; // Fields template
 
     // Make the context correct by replacing new_<parents> with the generated ID
     // of each of the parent objects

--- a/lib/generators/nested_form/templates/prototype_nested_form.js
+++ b/lib/generators/nested_form/templates/prototype_nested_form.js
@@ -2,7 +2,7 @@ document.observe('click', function(e, el) {
 	if (el = e.findElement('form a.add_nested_fields')) {
 	  // Setup
 	  var assoc   = el.readAttribute('data-association');           // Name of child
-	  var content = $(assoc + '_fields_blueprint').innerHTML; // Fields template
+      var content = window[assoc+'_fields_blueprint']; // Fields template
 
 	  // Make the context correct by replacing new_<parents> with the generated ID
 	  // of each of the parent objects

--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -21,10 +21,7 @@ module NestedForm
       @fields ||= {}
       @template.after_nested_form(association) do
         model_object = object.class.reflect_on_association(association).klass.new
-        output = %Q[<div id="#{association}_fields_blueprint" style="display: none">].html_safe
-        output << fields_for(association, model_object, :child_index => "new_#{association}", &@fields[association])
-        output.safe_concat('</div>')
-        output
+        "<script>window['#{association}_fields_blueprint']=\"#{@template.escape_javascript(fields_for(association, model_object, :child_index => "new_#{association}", &@fields[association]))}\";</script>"
       end
       @template.link_to(*args, &block)
     end

--- a/spec/nested_form/builder_spec.rb
+++ b/spec/nested_form/builder_spec.rb
@@ -29,13 +29,13 @@ require "spec_helper"
         end.should == '<div class="fields">Task</div><div class="fields">Task</div>'
       end
 
-      it "should add task fields to hidden div after form" do
+      it "should add task fields to window javascript variable" do
         pending
         output = ""
         mock(@template).after_nested_form(:tasks) { |arg, block| output << block.call }
         @builder.fields_for(:tasks) { "Task" }
         @builder.link_to_add("Add", :tasks)
-        output.should == '<div id="tasks_fields_blueprint" style="display: none"><div class="fields">Task</div></div>'
+        output.should == "<script>windows['tasks_fields_blueprint']=\"<div class=\"fields\">Task<\/div>\";</script>"
       end
     end
   end


### PR DESCRIPTION
Ryan,

Because of some trouble with a form built on table (same issue for lists).
Most browsers (eg chrome and firefox) do not like to have table rows not nested in table tag (or li in ul), which could append in the blueprint div tag.

In order to prevent lost of blueprint content, I had to send the blueprint in a javascript variable (like client_side_validation do...).

Some would says it is obtrusive javascript...
I respond to them, this gem need javascript to work, and adding nested fields without javascript is not supported in this context anyway.
