### PR TITLE
Add activerecord development dependency to be able to run specs

### DIFF
--- a/nested_form.gemspec
+++ b/nested_form.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"
 
+  s.add_development_dependency "activerecord", "~> 3.0"
   s.add_development_dependency "rspec-rails", "~> 2.6.0"
   s.add_development_dependency "mocha"
   # s.add_development_dependency "rails", "~> 3.1.0.rc"


### PR DESCRIPTION
I cloned the repo, changed to the working, permitted the .rvmrc file to create a fresh gemset, ran rake and received the following error:

slapshot:nested_form cdemyanovich$ rake
/Users/cdemyanovich/src/nested_form/spec/spec_helper.rb:8:in `require': no such file to load -- active_record (LoadError)
    from /Users/cdemyanovich/src/nested_form/spec/spec_helper.rb:8:in`<top (required)>'
    from /Users/cdemyanovich/src/nested_form/spec/nested_form/builder_spec.rb:1:in `require'
    from /Users/cdemyanovich/src/nested_form/spec/nested_form/builder_spec.rb:1:in`<top (required)>'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `load'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in`block in load_spec_files'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in `map'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/configuration.rb:419:in`load_spec_files'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/command_line.rb:18:in `run'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:80:in`run_in_process'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:69:in `run'
    from /Users/cdemyanovich/.rvm/gems/ruby-1.9.2-p290@nested_form/gems/rspec-core-2.6.4/lib/rspec/core/runner.rb:11:in`block in autorun'
rake aborted!
ruby -S bundle exec rspec ./spec/nested_form/builder_spec.rb ./spec/nested_form/view_helper_spec.rb failed

Tasks: TOP => default => spec
(See full trace by running task with --trace)
slapshot:nested_form cdemyanovich$

This pull request adds activerecord as a development dependency in the gemspec so that specs can be run immediately after a clone.
