### PR TITLE
Add additional class on div if object is marked for destruction

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -57,7 +57,9 @@ module NestedForm
     end
 
     def fields_for_nested_model(name, object, options, block)
-      output = '<div class="fields">'.html_safe
+      classes = ["fields"]
+      classes << "marked_for_destruction" if object.marked_for_destruction?
+      output = "<div class=\"#{classes.join(' ')}\">".html_safe
       output << super
       output.safe_concat('</div>')
       output

--- a/spec/nested_form/builder_spec.rb
+++ b/spec/nested_form/builder_spec.rb
@@ -29,6 +29,14 @@ require "spec_helper"
         end.should == '<div class="fields">Task</div><div class="fields">Task</div>'
       end
 
+      it "should wrap nested fields marked for destruction with an additional class" do
+        task = @project.tasks.build
+        task.mark_for_destruction
+        @builder.fields_for(:tasks) do
+          "Task"
+        end.should == '<div class="fields marked_for_destruction">Task</div>'
+      end
+
       it "should add task fields to hidden div after form" do
         pending
         output = ""


### PR DESCRIPTION
In order to choose how to handle, after validation errors,
fields that are marked for destruction, add an additional class
on the div if the object is marked for destruction. This allows
me to be sure the div is hidden. Or, I could use the additional
class to style the div and its contents if I prefer it to be
visible.
