### PR TITLE
When a set of fields are removed (hidden) the HTML5 required attribute

### DIFF
--- a/lib/generators/nested_form/templates/jquery_nested_form.js
+++ b/lib/generators/nested_form/templates/jquery_nested_form.js
@@ -44,8 +44,16 @@ jQuery(function($) {
     if(hidden_field) {
       hidden_field.value = '1';
     }
-    $(this).closest('.fields').hide();
-    $(this).closest("form").trigger('nested:fieldRemoved');
+    var field_set_to_hide = $(this).closest('.fields');
+    $(field_set_to_hide).hide();
+
+    // When a set of fields is removed, the HTML5 required attribute
+    // must also be removed to prevent silent errors that make the form inoperable
+    $(field_set_to_hide).children('div').children(':input[required]').each(function(idx, element) {
+      $(element).removeAttr('required');
+    });
+
+    $(this).closest("form").trigger({type: 'nested:fieldRemoved', field: field_set_to_hide});
     return false;
   });
 });


### PR DESCRIPTION
is now removed from those form fields. This should resolve issue #72 (https://github.com/ryanb/nested_form/issues/72).

Also, the nested:fieldRemoved trigger will now send the container div that is hidden in the field option so that it behaves like nested:fieldAdded. This will allow folks to do additional processing of those fields.
