### PR TITLE
Support for Formtastic 2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 appraise 'rails3' do
   gem 'rails', '~> 3.0.0'
-  gem 'formtastic'
+  gem 'formtastic', '~> 2.0.0.rc4'
 end
 
 appraise 'rails3_1' do

--- a/lib/nested_form/builders.rb
+++ b/lib/nested_form/builders.rb
@@ -12,10 +12,10 @@ module NestedForm
     end
   rescue LoadError
   end
-
+	
   begin
     require 'formtastic'
-    class FormtasticBuilder < ::Formtastic::SemanticFormBuilder
+    class FormtasticBuilder < ::Formtastic::FormBuilder
       include ::NestedForm::BuilderMixin
     end
   rescue LoadError


### PR DESCRIPTION
Formtastic 2 has depreciated "Formtastic::SemanticFormBuilder" resulting in the following depreciation notice.

```
DEPRECATION WARNING: Formtastic::SemanticFormBuilder has been
deprecated in favor of Formtastic::FormBuilder
```

In this commit I changed parent class to Formtastic::FormBuilder from
Formtastic::SemanticFormBuilder
