### PR TITLE
has_many through support for object building

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -32,6 +32,21 @@ module NestedForm
     # Based on link_to_add, but this builds an association for has_many => :through forms
     #
     #  f.link_to_add_hmt("Add Assocations", :singular_association, :plural_associations)
+    #
+    #  example case: 
+    #
+    #= f.fields_for :memberships do |mem|
+    #  = mem.fields_for :organisation do |org|
+    #    .row
+    #        = org.input :name, :label => "<strong>Name of the Organization</strong>"
+    #        = mem.input :title, :label => "<strong>Title in the Organization</strong>"
+    #    .row
+    #        = mem.input :starting_year, :label => "<strong>Starting Year</strong>"
+    #        = mem.input :ending_year, :label => "<strong>Ending Year</strong>"
+    #    .row
+    #        = org.text_area :description, :label => "<strong>Description of Organisation</strong>"
+    #  = mem.link_to_remove "Remove this oranisation"
+    #= f.link_to_add_hmt "Add an organisation", :organisation, :memberships
     def link_to_add_hmt(*args, &block)
       options = args.extract_options!.symbolize_keys
       association = args.pop


### PR DESCRIPTION
Hi I had trouble using this gem for has_many => :through scenarios. 

As would be the case below, if I used link_to_add :memberships below, the gem would build the membership but leave out its associated organisation. So I copied one of your methods and threw in another parameter to have it build the associated object. Below is a use case, you can see link_to_add_hmt in the pull request. Thanks!

  = f.fields_for :memberships do |mem|
    = mem.fields_for :organisation do |org|
      .row
        .span5.org_name
          = org.input :name, :label => "<strong>Name of the Organization</strong>"
        .span5
          = mem.input :title, :label => "<strong>Title in the Organization</strong>"
      .row
        .span5
          = mem.input :starting_year, :label => "<strong>Starting Year</strong>"
        .span5
          = mem.input :ending_year, :label => "<strong>Ending Year</strong>"
      .row
        .span10
          = org.text_area :description, :label => "<strong>Description of Organisation</strong>"
    = mem.link_to_remove "Remove this oranisation"
  = f.link_to_add_hmt "Add an organisation", :organisation, :memberships
