### PR TITLE
added mongoid support tip in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -26,6 +26,8 @@ Running the generator will add a file at <tt>public/javascripts/nested_form.js</
 
 Imagine you have a <tt>Project</tt> model that <tt>has_many :tasks</tt>. To be able to use this gem, you'll need to add <tt>accepts_nested_attributes_for :tasks</tt> to your Project model. If you don't have the <tt>accepts_nested_attributes_for :tasks</tt> you'll get a Missing Block Error.
 
+If you are using mongoid as your database, you should also add <tt>accepts_nested_attributes_for :tasks</tt> to your model even if it is already set up by default in embedded relationships.
+
 This will create a <tt>tasks_attributes=</tt> method, so you may need to add it to the <tt>attr_accessible</tt> array. (<tt>attr_accessible :tasks_attributes</tt>)
 
 Then use the +nested_form_for+ helper method to enable the nesting.


### PR DESCRIPTION
I couldn't find the solution to use nested_form to my app with mongoid.

I read a lot of times the documentation but i didn't figure out that the problem was the missing accepts_nested_attributes_for in my model.

I thought it was not necessary because this method is set up by default in embedded relationships, as in mondoig.org documentation.

hope i help!
