### PR TITLE
Formtastic 2.x support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,9 @@
 appraise 'rails3' do
   gem 'rails', '~> 3.0.0'
-  gem 'formtastic'
+  gem 'formtastic', '~> 1.0'
 end
 
 appraise 'rails3_1' do
   gem 'rails', '~> 3.1.0.rc4'
+  gem 'formtastic', '~> 2.0'
 end

--- a/lib/nested_form/builders.rb
+++ b/lib/nested_form/builders.rb
@@ -15,7 +15,11 @@ module NestedForm
 
   begin
     require 'formtastic'
-    class FormtasticBuilder < ::Formtastic::SemanticFormBuilder
+
+    # Formtastic 1.x compatibility
+    ::Formtastic::FormBuilder = ::Formtastic::SemanticFormBuilder unless defined?(::Formtastic::FormBuilder)
+    
+    class FormtasticBuilder < ::Formtastic::FormBuilder
       include ::NestedForm::BuilderMixin
     end
   rescue LoadError


### PR DESCRIPTION
Formtastic 2 deprecates `Formtastic::SemanticFormBuilder` in favour of `Formtastic::FormBuilder`, which makes Nested Form choke at application load.
