### PR TITLE
Include vendor folder in the gem for Rails 3.1 asset support.

### DIFF
--- a/nested_form.gemspec
+++ b/nested_form.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = "Gem to conveniently handle multiple models in a single form."
   s.description = "Gem to conveniently handle multiple models in a single form with Rails 3 and jQuery or Prototype."
 
-  s.files        = Dir["{lib,spec}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
+  s.files        = Dir["{lib,spec,vendor}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"
 
   s.add_development_dependency "rspec-rails", "~> 2.6.0"


### PR DESCRIPTION
The just-released 0.2.0 gem doesn't include the `vendor` folder, so including the gem on a Rails 3.1 project and using `//= require jquery_nested_form` in `application.js` throws a `couldn't find file 'jquery_nested_form'` error.
