### PR TITLE
Refactored jQuery code

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -1,4 +1,4 @@
-jQuery(function($) {
+(function($) {
   window.NestedFormEvents = function() {
     this.addFields = $.proxy(this.addFields, this);
     this.removeFields = $.proxy(this.removeFields, this);
@@ -68,4 +68,4 @@ jQuery(function($) {
   window.nestedFormEvents = new NestedFormEvents();
   $('form a.add_nested_fields').live('click', nestedFormEvents.addFields);
   $('form a.remove_nested_fields').live('click', nestedFormEvents.removeFields);
-});
+})(jQuery);

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -1,23 +1,23 @@
-document.observe('click', function(e, el) {
-	if (el = e.findElement('form a.add_nested_fields')) {
-	  // Setup
-	  var assoc   = el.readAttribute('data-association');           // Name of child
-	  var content = $(assoc + '_fields_blueprint').innerHTML; // Fields template
+document.observe('click', function (e, el) {
+  if (el = e.findElement('form a.add_nested_fields')) {
+    // Setup
+    var assoc = el.readAttribute('data-association');           // Name of child
+    var content = $(assoc + '_fields_blueprint').innerHTML; // Fields template
 
-	  // Make the context correct by replacing new_<parents> with the generated ID
-	  // of each of the parent objects
-	  var context = (el.getOffsetParent('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+    // Make the context correct by replacing new_<parents> with the generated ID
+    // of each of the parent objects
+    var context = (el.getOffsetParent('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
 
-	  // context will be something like this for a brand new form:
-	  // project[tasks_attributes][new_1255929127459][assignments_attributes][new_1255929128105]
-	  // or for an edit form:
-	  // project[tasks_attributes][0][assignments_attributes][1]
-	  if(context) {
-	    var parent_names = context.match(/[a-z_]+_attributes/g) || [];
-	    var parent_ids   = context.match(/(new_)?[0-9]+/g) || [];
+    // context will be something like this for a brand new form:
+    // project[tasks_attributes][new_1255929127459][assignments_attributes][new_1255929128105]
+    // or for an edit form:
+    // project[tasks_attributes][0][assignments_attributes][1]
+    if (context) {
+      var parent_names = context.match(/[a-z_]+_attributes/g) || [];
+      var parent_ids = context.match(/(new_)?[0-9]+/g) || [];
 
-	    for(i = 0; i < parent_names.length; i++) {
-        if(parent_ids[i]) {
+      for (i = 0; i < parent_names.length; i++) {
+        if (parent_ids[i]) {
           content = content.replace(
             new RegExp('(_' + parent_names[i] + ')_.+?_', 'g'),
             '$1_' + parent_ids[i] + '_');
@@ -26,26 +26,26 @@ document.observe('click', function(e, el) {
             new RegExp('(\\[' + parent_names[i] + '\\])\\[.+?\\]', 'g'),
             '$1[' + parent_ids[i] + ']');
         }
-	    }
-	  }
+      }
+    }
 
-	  // Make a unique ID for the new child
-	  var regexp  = new RegExp('new_' + assoc, 'g');
-	  var new_id  = new Date().getTime();
-	  content     = content.replace(regexp, "new_" + new_id);
+    // Make a unique ID for the new child
+    var regexp = new RegExp('new_' + assoc, 'g');
+    var new_id = new Date().getTime();
+    content = content.replace(regexp, "new_" + new_id);
 
-	  el.insert({ before: content });
-	  return false;
-	}
+    el.insert({ before:content });
+    return false;
+  }
 });
 
-document.observe('click', function(e, el) {
-  	if (el = e.findElement('form a.remove_nested_fields')) {
-		var hidden_field = el.previous(0);
-		if(hidden_field) {
-		  hidden_field.value = '1';
-		}
-		el.ancestors()[0].hide();
-		return false;
-	}
+document.observe('click', function (e, el) {
+  if (el = e.findElement('form a.remove_nested_fields')) {
+    var hidden_field = el.previous(0);
+    if (hidden_field) {
+      hidden_field.value = '1';
+    }
+    el.ancestors()[0].hide();
+    return false;
+  }
 });


### PR DESCRIPTION
- Now jQuery does not wait until document:ready to apply event handlers.
  This is possible because we use live events and it requires only
  document object to be loaded.
- Reformatted prototype code (converted tabs to spaces).
