### PR TITLE
Make the "context" selector stricter, to work with deeply-nested forms.

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -13,7 +13,8 @@ jQuery(function($) {
 
       // Make the context correct by replacing new_<parents> with the generated ID
       // of each of the parent objects
-      var context = ($(link).closest('.fields').find('input:first').attr('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+      var context = ($(link).closest('.fields').closestChild('input:first').attr('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+
 
       // context will be something like this for a brand new form:
       // project[tasks_attributes][new_1255929127459][assignments_attributes][new_1255929128105]
@@ -69,3 +70,34 @@ jQuery(function($) {
   $('form a.add_nested_fields').live('click', nestedFormEvents.addFields);
   $('form a.remove_nested_fields').live('click', nestedFormEvents.removeFields);
 });
+
+
+// http://plugins.jquery.com/project/closestChild
+/*
+ * Copyright 2011, Tobias Lindig
+ *
+ * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+ * and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
+ *
+ */
+(function($) {
+  $.fn.closestChild = function(selector) {
+    // breadth first search for the first matched node
+    if (selector && selector != '') {
+      var queue = [];
+      queue.push(this);
+      while(queue.length > 0) {
+        var node = queue.shift();
+        var children = node.children();
+        for(var i = 0; i < children.length; ++i) {
+          var child = $(children[i]);
+          if (child.is(selector)) {
+            return child; //well, we found one
+          }
+          queue.push(child);
+        }
+      }
+    }
+    return $();//nothing found
+  };
+})(jQuery);


### PR DESCRIPTION
#78 no longer applies cleanly, so I made this commit. 99% of the work in this commit came from @groe in #78 .

See #77 for a description of the problem.
