### PR TITLE
Fix: Element.up() is the proper Prototype counter part to jQuery's closest()

### DIFF
--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -6,7 +6,7 @@ document.observe('click', function(e, el) {
 
 	  // Make the context correct by replacing new_<parents> with the generated ID
 	  // of each of the parent objects
-	  var context = (el.getOffsetParent('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+	  var context = (el.up('.fields').firstDescendant().readAttribute('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
 
 	  // context will be something like this for a brand new form:
 	  // project[tasks_attributes][new_1255929127459][assignments_attributes][new_1255929128105]
@@ -45,7 +45,7 @@ document.observe('click', function(e, el) {
 		if(hidden_field) {
 		  hidden_field.value = '1';
 		}
-		el.ancestors()[0].hide();
+		el.up('.fields').hide();
 		return false;
 	}
 });


### PR DESCRIPTION
The existing code uses Element.getOffsetParent() in one place and Element.ancestors()[0] in another place to mimic jQuery's closest() function to get the wrapper with class fields. This pull request replaces both occurrences with Element.up('.fields') which, for this purpose, works like jQuery's closest() function (also see http://stackoverflow.com/questions/2366367/prototype-equivalent-for-jquery-closest-function).

This is needed especially when have additional markup where the link/button to remove the nested fields isn't a direct child of the wrapper.
