### PR TITLE
Fix for included nested forms with the same name

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -14,15 +14,16 @@ module NestedForm
     def link_to_add(*args, &block)
       options = args.extract_options!.symbolize_keys
       association = args.pop
+      assoc_id = "#{object.class.to_s.underscore}_#{association}"
       options[:class] = [options[:class], "add_nested_fields"].compact.join(" ")
-      options["data-association"] = association
+      options["data-association"] = assoc_id
       args << (options.delete(:href) || "javascript:void(0)")
       args << options
       @fields ||= {}
-      @template.after_nested_form(association) do
+      @template.after_nested_form(assoc_id) do
         model_object = object.class.reflect_on_association(association).klass.new
-        blueprint = fields_for(association, model_object, :child_index => "new_#{association}", &@fields[association])
-        blueprint_options = {:id => "#{association}_fields_blueprint", :style => 'display: none'}
+        blueprint = fields_for(association, model_object, :child_index => "new_#{assoc_id}", &@fields[association])
+        blueprint_options = {:id => "#{assoc_id}_fields_blueprint", :style => 'display: none'}
         @template.content_tag(:div, blueprint, blueprint_options)
       end
       @template.link_to(*args, &block)


### PR DESCRIPTION
*Issue:

<pre>
= nested_form_for @project do |f|
  ....
  = f.fields_for :options do |option_form|
     ...
     = option_form.fields_for :photos do |photo_form|
        ...
     = option_form.link_to_add 'Add photo to option', :photos
  = f.link_to_add 'Add option', :options
  ...
  = f.fields_for :photos do |photo_form|
    = f.link_to_add 'Add photo to project', :photos
</pre>

Gem will create only 2 templates 'photos_fields_blueprint' and 'options_fields_blueprint'. So, adding photos to project will not work, because it will use template of "adding photo to option" .

This patch naming templates with form object class name and association name, that solves the problem.
Sorry for my English.
