### PR TITLE
Fix issue with RegExp for getting context and replace context in blueprint

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -14,7 +14,7 @@ jQuery(function($) {
 
       // Make the context correct by replacing <parents> with the generated ID
       // of each of the parent objects
-      var context = ($(link).closest('.fields').closestChild('input, textarea').eq(0).attr('name') || '').replace(new RegExp('\[[a-z]+\]$'), '');
+      var context = ($(link).closest('.fields').closestChild('input, textarea').eq(0).attr('name') || '').replace(new RegExp('\\[[a-z]+\\]$'), '');
 
       // context will be something like this for a brand new form:
       // project[tasks_attributes][1255929127459][assignments_attributes][1255929128105]
@@ -27,11 +27,11 @@ jQuery(function($) {
         for(var i = 0; i < parentNames.length; i++) {
           if(parentIds[i]) {
             content = content.replace(
-              new RegExp('(_' + parentNames[i] + ')_.+?_', 'g'),
+              new RegExp('(_' + parentNames[i] + ')_\\d+_', 'g'),
               '$1_' + parentIds[i] + '_');
 
             content = content.replace(
-              new RegExp('(\\[' + parentNames[i] + '\\])\\[.+?\\]', 'g'),
+              new RegExp('(\\[' + parentNames[i] + '\\])\\[\\d+\\]', 'g'),
               '$1[' + parentIds[i] + ']');
           }
         }


### PR DESCRIPTION
Fix issue with getting contex. Javascript always replace backslash.

Also fix issue with replace context parents in content. For example:

```
project[tasks_attributes][0][assigments_sttributes[new_assigments][file_name]
```

will be replaced to

```
project[tasks_attributes][0][assigments_sttributes[0][file_name]
```

and will replace first child object after post.
