### PR TITLE
make nested_form work on rails4

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -39,7 +39,8 @@ module NestedForm
       @template.after_nested_form(fields_blueprint_id) do
         blueprint = {:id => fields_blueprint_id, :style => 'display: none'}
         block, options = @fields[fields_blueprint_id].values_at(:block, :options)
-        options[:child_index] = "new_#{association}"
+        options_key = Rails::VERSION::MAJOR>=4 ? :index : :child_index
+        options[options_key] = "new_#{association}"
         blueprint[:"data-blueprint"] = fields_for(association, model_object, options, &block).to_str
         @template.content_tag(:div, nil, blueprint)
       end


### PR DESCRIPTION
Due to different way of naming nested fields introduced in this commit:
https://github.com/rails/rails/commit/47cbfbb98a2a4ccb6d434998183f24be4e2bb1c1#L1R1130 

nested_form stoped working - it was not adding middle part with either object id or timestamp. This commit may not be the best possible solution, but makes it work in rails4 and preserves compatibility with rails3
