### PR TITLE
Update lib/nested_form/builder_mixin.rb

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -88,10 +88,15 @@ module NestedForm
     end
 
     def fields_for_nested_model(name, object, options, block)
+      begin
+        wrapper_off = true if object.class.wrapper_off?
+      rescue
+        wrapper_off = false
+      end
       classes = 'fields'
       classes << ' marked_for_destruction' if object.respond_to?(:marked_for_destruction?) && object.marked_for_destruction?
 
-      if options[:wrapper] != false # wrap even if nil
+      if options[:wrapper] != false && wrapper_off != true # wrap even if nil
         @template.content_tag(:div, super, :class => classes)
       else
         super


### PR DESCRIPTION
I use twitter bootstrap  and I needed use a tabs for my form
gem nested form make wrap all .simple_fields_for fields, but if it don't needed,
we can't disable it

like my nested has_many model for example:
%ul.nav.nav-tabs#project-tabs
  %li.active= link_to ...
  %li= link_to ...
.tab-content
  = f.simple_fields_for :project_contents do |content|
    .tab-pane
But if will make wrap simple_fields_for - it's will crashed tabs

For disable it, after commit - In your nested model
def self.wrapper_off?
  true
end
