### PR TITLE
Javascript fails to generate correct html for doubly nested forms

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -16,27 +16,6 @@
       // of each of the parent objects
       var context = ($(link).closest('.fields').closestChild('input, textarea, select').eq(0).attr('name') || '').replace(new RegExp('\[[a-z_]+\]$'), '');
 
-      // context will be something like this for a brand new form:
-      // project[tasks_attributes][1255929127459][assignments_attributes][1255929128105]
-      // or for an edit form:
-      // project[tasks_attributes][0][assignments_attributes][1]
-      if (context) {
-        var parentNames = context.match(/[a-z_]+_attributes/g) || [];
-        var parentIds   = context.match(/[0-9]+/g) || [];
-
-        for(var i = 0; i < parentNames.length; i++) {
-          if(parentIds[i]) {
-            content = content.replace(
-              new RegExp('(_' + parentNames[i] + ')_.+?_', 'g'),
-              '$1_' + parentIds[i] + '_');
-
-            content = content.replace(
-              new RegExp('(\\[' + parentNames[i] + '\\])\\[.+?\\]', 'g'),
-              '$1[' + parentIds[i] + ']');
-          }
-        }
-      }
-
       // Make a unique ID for the new child
       var regexp  = new RegExp('new_' + assoc, 'g');
       var new_id  = this.newId();


### PR DESCRIPTION
If you have a doubly nested creation form, the javascript will incorrectly strip out the name of the second association and replace it with an integer, breaking the form.  Also i think this fixes issue #26.
