### PR TITLE
fix "has_one => has_many => has_many" name generation

### DIFF
--- a/spec/dummy/app/assets/stylesheets/companies.css
+++ b/spec/dummy/app/assets/stylesheets/companies.css
@@ -1,0 +1,4 @@
+/*
+  Place all the styles related to the matching controller here.
+  They will automatically be included in application.css.
+*/

--- a/spec/dummy/app/controllers/companies_controller.rb
+++ b/spec/dummy/app/controllers/companies_controller.rb
@@ -1,0 +1,5 @@
+class CompaniesController < ApplicationController
+  def new
+    @company = Company.new
+  end
+end

--- a/spec/dummy/app/models/company.rb
+++ b/spec/dummy/app/models/company.rb
@@ -1,0 +1,6 @@
+class Company < ActiveRecord::Base
+  has_one :project
+  accepts_nested_attributes_for :project
+
+  after_initialize 'self.build_project'
+end

--- a/spec/dummy/app/views/companies/new.html.erb
+++ b/spec/dummy/app/views/companies/new.html.erb
@@ -1,0 +1,16 @@
+<%= nested_form_for @company do |f| -%>
+  <%= f.text_field :name %>
+  <%= f.fields_for :project do |pf| -%>
+    <%= pf.text_field :name %>
+    <%= pf.fields_for :tasks do |tf| -%>
+      <%= tf.text_field :name %>
+      <%= tf.fields_for :milestones do |mf| %>
+        <%= mf.text_field :name %>
+        <%= mf.link_to_remove 'Remove milestone' %>
+      <% end %>
+      <%= tf.link_to_add 'Add new milestone', :milestones %>
+      <%= tf.link_to_remove 'Remove' %>
+    <% end -%>
+    <%= pf.link_to_add 'Add new task', :tasks %>
+  <% end -%>
+<% end -%>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Dummy::Application.routes.draw do
+  resources :companies, :only => %w(new create)
   resources :projects, :only => %w(new create)
   get '/:controller/:action'
 

--- a/spec/dummy/db/migrate/20130203095901_create_company.rb
+++ b/spec/dummy/db/migrate/20130203095901_create_company.rb
@@ -1,0 +1,14 @@
+class CreateCompany < ActiveRecord::Migration
+  def self.up
+    create_table :companies do |t|
+      t.string :name
+    end
+
+    add_column :projects, :company_id, :integer
+  end
+
+  def self.down
+    remove_column :projects, :company_id
+    drop_table :companies
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,11 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120819164528) do
+ActiveRecord::Schema.define(:version => 20130203095901) do
+
+  create_table "companies", :force => true do |t|
+    t.string "name"
+  end
 
   create_table "milestones", :force => true do |t|
     t.integer "task_id"
@@ -24,7 +28,8 @@ ActiveRecord::Schema.define(:version => 20120819164528) do
   end
 
   create_table "projects", :force => true do |t|
-    t.string "name"
+    t.string  "name"
+    t.integer "company_id"
   end
 
   create_table "tasks", :force => true do |t|

--- a/spec/form_spec.rb
+++ b/spec/form_spec.rb
@@ -47,4 +47,20 @@ describe 'NestedForm' do
     name = find('.fields .fields input[id$=name]')[:name]
     name.should match(/\Aproject\[tasks_attributes\]\[\d+\]\[milestones_attributes\]\[\d+\]\[name\]\z/)
   end
+
+  it 'generates correct name for the nested input (has_one => has_many)', :js => true do
+    visit '/companies/new?type=jquery'
+    click_link 'Add new task'
+    name = find('.fields .fields input[id$=name]')[:name]
+    name.should match(/\Acompany\[project_attributes\]\[tasks_attributes\]\[\d+\]\[name\]\z/)
+  end
+
+  it 'generates correct name for the nested input (has_one => has_many => has_many)', :js => true do
+    visit '/companies/new?type=jquery'
+    click_link 'Add new task'
+    click_link 'Add new milestone'
+    name = find('.fields .fields .fields input[id$=name]')[:name]
+    name.should match(/\Acompany\[project_attributes\]\[tasks_attributes\]\[\d+\]\[milestones_attributes\]\[\d+\]\[name\]\z/)
+  end
+
 end

--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -21,7 +21,7 @@
       // or for an edit form:
       // project[tasks_attributes][0][assignments_attributes][1]
       if (context) {
-        var parentNames = context.match(/[a-z_]+_attributes/g) || [];
+        var parentNames = context.match(/[a-z_]+_attributes(?=\]\[(new_)?\d+\])/g) || [];
         var parentIds   = context.match(/[0-9]+/g) || [];
 
         for(var i = 0; i < parentNames.length; i++) {

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -14,7 +14,7 @@ document.observe('click', function(e, el) {
     // or for an edit form:
     // project[tasks_attributes][0][assignments_attributes][1]
     if(context) {
-      var parent_names = context.match(/[a-z_]+_attributes/g) || [];
+      var parent_names = context.match(/[a-z_]+_attributes(?=\]\[(new_)?\d+\])/g) || [];
       var parent_ids   = context.match(/[0-9]+/g) || [];
 
       for(i = 0; i < parent_names.length; i++) {


### PR DESCRIPTION
reworked patch from #125 (thanks to kevinrood) with added specs.

Specs should probably be refactored to something nicer, but it makes the case for the "has_one => has_many => has_many" situation. 
I also added a "has_one => has_many" case to show that it didn't break there yet.
