### PR TITLE
Allow DOM target to be specified when adding new nested form elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,33 @@ It is often desirable to move the nested fields into a partial to keep things or
 In this case it will look for a partial called "task_fields" and pass the form builder as an `f` variable to it.
 
 
+## Specifying a Target for Nested Fields
+
+By default, `link_to_add` appends fields immediately before the link when
+clicked.  This is not desirable when using a list or table, for example.  In
+these situations, the "data-target" attribute can be used to specify where new
+fields should be inserted.
+
+```erb
+<table id="tasks">
+  <%= f.fields_for :tasks, :wrapper => false do |task_form| %>
+    <tr class="fields">
+      <td><%= task_form.text_field :name %></td>
+      </td><%= task_form.link_to_remove "Remove this task" %></td>
+    </tr>
+  <% end %>
+</table>
+<p><%= f.link_to_add "Add a task", :tasks, :data => { :target => "#tasks" } %></p>
+```
+
+Note that the `:data` option above only works in Rails 3.1+.  For Rails 3.0 and
+below, the following syntax must be used.
+
+```erb
+<p><%= f.link_to_add "Add a task", :tasks, "data-target" => "#tasks" %></p>
+```
+
+
 ## JavaScript events
 
 Sometimes you want to do some additional work after element was added or removed, but only

--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -40,7 +40,7 @@
       // Make a unique ID for the new child
       var regexp  = new RegExp('new_' + assoc, 'g');
       var new_id  = this.newId();
-      content     = content.replace(regexp, new_id);
+      content     = $.trim(content.replace(regexp, new_id));
 
       var field = this.insertFields(content, assoc, link);
       // bubble up event upto document (through form)
@@ -53,7 +53,12 @@
       return new Date().getTime();
     },
     insertFields: function(content, assoc, link) {
-      return $(content).insertBefore(link);
+      var target = $(link).data('target');
+      if (target) {
+        return $(content).appendTo($(target));
+      } else {
+        return $(content).insertBefore(link);
+      }
     },
     removeFields: function(e) {
       var $link = $(e.currentTarget),

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -2,6 +2,7 @@ document.observe('click', function(e, el) {
   if (el = e.findElement('form a.add_nested_fields')) {
     // Setup
     var assoc     = el.readAttribute('data-association');      // Name of child
+    var target    = el.readAttribute('data-target');
     var blueprint = $(el.readAttribute('data-blueprint-id'));
     var content   = blueprint.readAttribute('data-blueprint'); // Fields template
 
@@ -35,7 +36,12 @@ document.observe('click', function(e, el) {
     var new_id  = new Date().getTime();
     content     = content.replace(regexp, new_id);
 
-    var field = el.insert({ before: content });
+    var field;
+    if (target) {
+      field = $$(target)[0].insert(content);
+    } else {
+      field = el.insert({ before: content });
+    }
     field.fire('nested:fieldAdded', {field: field});
     field.fire('nested:fieldAdded:' + assoc, {field: field});
     return false;


### PR DESCRIPTION
These changes allow nested form elements to be appended to any DOM element rather than just inserting before the link.  This is useful when you're adding to a `TABLE`, `UL`, `OL`, or any other element that does not share the same parent as the `add_to_link`.

Example usage:

```
%table
  %thead
    %th
      %td Ingredient
      %td Quantity
      %td Unit
      %td &nbsp;
  %tbody#ingredients
    =f.fields_for :recipes_ingredients, wrapper: false do |i|
      %tr.fields
        %td= i.input :ingredient_id, label: false, collection: Ingredient.order(:name)
        %td= i.input :quantity, label: false
        %td= i.input :unit_id, label: false, collection: Unit.order(:name)
        %td= i.link_to_remove 'Remove'
%p= f.link_to_add 'Add Ingredient', :recipes_ingredients, target: 'ingredients'
```
