### PR TITLE
Allow nested associations with same name (fixes #237)

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -21,18 +21,22 @@
       // or for an edit form:
       // project[tasks_attributes][0][assignments_attributes][1]
       if (context) {
+        var prevParentsId = "";
+        var prevParentsName = "";
         var parentNames = context.match(/[a-z_]+_attributes(?=\]\[(new_)?\d+\])/g) || [];
         var parentIds   = context.match(/[0-9]+/g) || [];
 
         for(var i = 0; i < parentNames.length; i++) {
           if(parentIds[i]) {
             content = content.replace(
-              new RegExp('(_' + parentNames[i] + ')_.+?_', 'g'),
+              new RegExp('(_' + prevParentsId + parentNames[i] + ')_.+?_', 'g'),
               '$1_' + parentIds[i] + '_');
+            prevParentsId += "_" + parentNames[i] + "_" + parentIds[i] + "_";
 
             content = content.replace(
-              new RegExp('(\\[' + parentNames[i] + '\\])\\[.+?\\]', 'g'),
+              new RegExp('(' + prevParentsName + '\\[' + parentNames[i] + '\\])\\[.+?\\]', 'g'),
               '$1[' + parentIds[i] + ']');
+            prevParentsName += "\\[" + parentNames[i] + "\\]\\[" + parentIds[i] + "\\]";
           }
         }
       }


### PR DESCRIPTION
This fixes #237 by using more specific regular expressions for nested associations.

**Example**
Think of this model: A has_many B. B has_many B.

Right now if you are in the form of A and click the add link, the blueprint will be loaded and every occurence of the regexp `/(_b_attributes)_.+?_/g` will be replaced with `$1_0_` and every occurence of `/(\[b_attributes\])\[.+?\]/g` will be replaced with `$1[0]`. Thats okay for the first nesting level (as this contains simple names as `a[b_attributes][new_b][_destroy]`). However, in the second level (e.g. name = `a[b_attributes][new_b][b_attributes][new_b][_destroy]`) this will not work anymore, as the first replace will catch both occurences of both associations since they have the same name.

My patch is to make the regexps more specific by prepending the _full path_ of the parent associations.

This pull request does not entirely fix support for recursive associations, but it allows users to fix it on their own, see #237 on how to. Of course, it would be awesome if even that wouldn't be necessary some day.
