### PR TITLE
Added posibility specify helper for link_to_add and link_to_remove

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -28,11 +28,13 @@ module NestedForm
         reflection = object.class.reflect_on_association(association)
         reflection.klass.new
       end
+      
+      helper = options.delete(:helper) || :link_to
 
       options[:class] = [options[:class], "add_nested_fields"].compact.join(" ")
       options["data-association"] = association
       options["data-blueprint-id"] = fields_blueprint_id = fields_blueprint_id_for(association)
-      args << (options.delete(:href) || "javascript:void(0)")
+      args << (options.delete(:href) || "javascript:void(0)") if helper == :link_to
       args << options
 
       @fields ||= {}
@@ -43,7 +45,7 @@ module NestedForm
         blueprint[:"data-blueprint"] = fields_for(association, model_object, options, &block).to_str
         @template.content_tag(:div, nil, blueprint)
       end
-      @template.link_to(*args, &block)
+      @template.send helper, *args, &block
     end
 
     # Adds a link to remove the associated record. The first argment is the name of the link.
@@ -65,10 +67,12 @@ module NestedForm
       md = object_name.to_s.match /(\w+)_attributes\]\[[\w\d]+\]$/
       association = md && md[1]
       options["data-association"] = association
+      
+      helper = options.delete(:helper) || :link_to
 
-      args << (options.delete(:href) || "javascript:void(0)")
+      args << (options.delete(:href) || "javascript:void(0)") if helper == :link_to
       args << options
-      hidden_field(:_destroy) << @template.link_to(*args, &block)
+      hidden_field(:_destroy) << @template.send(helper, *args, &block)
     end
 
     def fields_for_with_nested_attributes(association_name, *args)

--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -74,8 +74,8 @@
 
   window.nestedFormEvents = new NestedFormEvents();
   $(document)
-    .delegate('form a.add_nested_fields',    'click', nestedFormEvents.addFields)
-    .delegate('form a.remove_nested_fields', 'click', nestedFormEvents.removeFields);
+    .delegate('form .add_nested_fields',    'click', nestedFormEvents.addFields)
+    .delegate('form .remove_nested_fields', 'click', nestedFormEvents.removeFields);
 })(jQuery);
 
 // http://plugins.jquery.com/project/closestChild

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -1,5 +1,5 @@
 document.observe('click', function(e, el) {
-  if (el = e.findElement('form a.add_nested_fields')) {
+  if (el = e.findElement('form .add_nested_fields')) {
     // Setup
     var assoc     = el.readAttribute('data-association');      // Name of child
     var blueprint = $(el.readAttribute('data-blueprint-id'));
@@ -43,7 +43,7 @@ document.observe('click', function(e, el) {
 });
 
 document.observe('click', function(e, el) {
-  if (el = e.findElement('form a.remove_nested_fields')) {
+  if (el = e.findElement('form .remove_nested_fields')) {
     var hidden_field = el.previous(0),
         assoc = el.readAttribute('data-association'); // Name of child to be removed
     if(hidden_field) {


### PR DESCRIPTION
Sometimes we need specify tag that `link_to_add` or `link_to_remove` generated.
So i have added posibility to specify `:helper` options to choose view helper that generate link

``` ruby
= f.link_to_add 'Add new task', :tasks, helper: :button_tag
```
