### PR TITLE
Change the default href for a tag in link_to_add helper.

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -32,7 +32,7 @@ module NestedForm
       options[:class] = [options[:class], "add_nested_fields"].compact.join(" ")
       options["data-association"] = association
       options["data-blueprint-id"] = fields_blueprint_id = fields_blueprint_id_for(association)
-      args << (options.delete(:href) || "javascript:void(0)")
+      args << (options.delete(:href) || "#")
       args << options
 
       @fields ||= {}


### PR DESCRIPTION
When isn`t placed the href option to link_to_add helper. It set the default "javascript:void(0)".
But when you use Capybara with RSpec, and use the click_link and pass the content of link, it returns an error. When the href option in link_to_add to '#',  it works. So my opinion its good make the default '#' which work with tests with rspec.
