### PR TITLE
Fix id generation if parent has no input

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -18,7 +18,9 @@
 
       // If the parent has no inputs we need to strip off the last pair
       var current = content.match(new RegExp('\\[([a-z_]+)\\]\\[new_' + assoc + '\\]'))[1];
-      context = context.replace(new RegExp('\\['+current+'\\]\\[(new_)?\\d+\\]$'), '');
+      if (current) {
+        context = context.replace(new RegExp('\\['+current+'\\]\\[(new_)?\\d+\\]$'), '');
+      }
 
       // context will be something like this for a brand new form:
       // project[tasks_attributes][1255929127459][assignments_attributes][1255929128105]

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -12,7 +12,9 @@ document.observe('click', function(e, el) {
 
     // If the parent has no inputs we need to strip off the last pair
     var current = content.match(new RegExp('\\[([a-z_]+)\\]\\[new_' + assoc + '\\]'))[1];
-    context = context.replace(new RegExp('\\['+current+'\\]\\[(new_)?\\d+\\]$'), '');
+    if (current) {
+      context = context.replace(new RegExp('\\['+current+'\\]\\[(new_)?\\d+\\]$'), '');
+    }
 
     // context will be something like this for a brand new form:
     // project[tasks_attributes][1255929127459][assignments_attributes][1255929128105]


### PR DESCRIPTION
If the parent form had no inputs

``` javascript
var context = ($(link).closest('.fields').closestChild('input, textarea, select').eq(0).attr('name') || '').replace(/\[[a-z_]+\]$/, '');
```

would have picked up too much. The subsequent loop would have replaced the `[some_attributes][new_assoc]`-part with `[some_attributes][1]` (or whetever id was present).

This pull request works around that case by stripping the context accordingly.

Specs still pass but I haven't added any new ones.
