### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rails g nested_form:install
 You can then include the generated JavaScript in your layout.
 
 ```erb
-<%= javascript_include_tag :defaults, "nested_form" %>
+<%= javascript_include_tag "application", "nested_form" %>
 ```
 
 ## Usage


### PR DESCRIPTION
Rails apps >= 3.1 should use "application" rather than :defaults -- this causes errors in Rail 3.2.13 with the explicit nested_form JS require.
