### PR TITLE
Pass along click events when fieldAdded and fieldRemoved events are triggered

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -45,8 +45,8 @@
       var field = this.insertFields(content, assoc, link);
       // bubble up event upto document (through form)
       field
-        .trigger({ type: 'nested:fieldAdded', field: field })
-        .trigger({ type: 'nested:fieldAdded:' + assoc, field: field });
+        .trigger({ type: 'nested:fieldAdded', field: field, clickEvent: e })
+        .trigger({ type: 'nested:fieldAdded:' + assoc, field: field, clickEvent: e });
       return false;
     },
     newId: function() {
@@ -71,8 +71,8 @@
       field.hide();
       
       field
-        .trigger({ type: 'nested:fieldRemoved', field: field })
-        .trigger({ type: 'nested:fieldRemoved:' + assoc, field: field });
+        .trigger({ type: 'nested:fieldRemoved', field: field, clickEvent: e })
+        .trigger({ type: 'nested:fieldRemoved:' + assoc, field: field, clickEvent: e });
       return false;
     }
   };


### PR DESCRIPTION
I found the need to have 2 different "Add" links that caused changes in the fields depending on which one was clicked. But the only way to know which one was clicked was to pass along the click event.
