### PR TITLE
Allow to override the wrapper's class name

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -88,7 +88,7 @@ module NestedForm
     end
 
     def fields_for_nested_model(name, object, options, block)
-      classes = options.fetch(:nested_wrapper_class, '')
+      classes = options.fetch(:nested_wrapper_class, '').dup
       classes << ' fields'
       classes << ' marked_for_destruction' if object.respond_to?(:marked_for_destruction?) && object.marked_for_destruction?
 


### PR DESCRIPTION
I was need to override default wrapper's "fields" class with some twitter bootstrap col-\* classes.
