### PR TITLE
hide elements from DOM if _destroy="true" after validation errors

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -67,7 +67,7 @@
       }
     },
     removeFields: function(e) {
-      var $link = $(e.currentTarget),
+      var $link = $((e instanceof jQuery.Event) ? e.currentTarget : e),
           assoc = $link.data('association'); // Name of child to be removed
       
       var hiddenField = $link.prev('input[type=hidden]');
@@ -118,3 +118,9 @@
                 return $();//nothing found
         };
 })(jQuery);
+
+$(function() {
+  nestedFormEvents.removeFields(
+    $('input[name$="[_destroy]"][value="true"]').siblings('a.remove_nested_fields')
+  );
+})


### PR DESCRIPTION
When we remove the nested element by clicking on `Remove` link then we hide the elements using JS, but then if we submit the form and error occurs, form again renders and the last removed(hidden) elements have shown on the DOM with _destroy="true", and now if submit the form correctly, it passes the params with _destroy="true" => which would destroy the nested elements, so I think we should not display the last removed(hidden) elements after errors occur on the server.
