### PR TITLE
Add support for partial option

### DIFF
--- a/lib/nested_form/builder_mixin.rb
+++ b/lib/nested_form/builder_mixin.rb
@@ -72,16 +72,19 @@ module NestedForm
     end
 
     def fields_for_with_nested_attributes(association_name, *args)
-      options = args.dup.extract_options!
-      options[:partial] ||= "#{association_name.to_s.singularize}_fields"
-
       # TODO Test this better
-      block = args.pop || Proc.new { |fields| @template.render(:partial => options[:partial], :locals => {:f => fields}) }
+      block = args.pop
+
+      options = args.dup.extract_options!
 
       # Rails 3.0.x
       if options.empty? && args[0].kind_of?(Array)
         options = args[0].dup.extract_options!
       end
+      
+      # Check for a :partial option or use the default
+      partial = options.delete(:partial) || "#{association_name.to_s.singularize}_fields"
+      block ||= Proc.new { |fields| @template.render(:partial => partial, :locals => {:f => fields}) }
 
       @fields ||= {}
       @fields[fields_blueprint_id_for(association_name)] = { :block => block, :options => options }


### PR DESCRIPTION
Allow for a :partial option when not using a block in form_for. Useful in case you want to use something besides the "#{association_name.to_s.singularize}_fields" partial. For example, if you have a polymorphic association in which the nested fields would be the same throughout the application. It's cleaner than the suggestion here: https://github.com/ryanb/nested_form/issues/167

I also updated the README file to explain this option, but I don't think that is showing in this pull request. You can see it on my master branch. What can I do to include the updated documentation?
