### PR TITLE
Add the generated ID as a data attribute to the new field

### DIFF
--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -49,6 +49,8 @@
       content     = $.trim(content.replace(regexp, new_id));
 
       var field = this.insertFields(content, assoc, link);
+      field.data('new-id', new_id);
+
       // bubble up event upto document (through form)
       field
         .trigger({ type: 'nested:fieldAdded', field: field })


### PR DESCRIPTION
I'm using EJS to add new nested fields to the page after making an AJAX request to the server. The issue is that with multi-level nesting, this can get quite messy since there's no easy way to find the parent ID except with a regexp.

A simple solution would be to add a data attribute to each newly added field that contains the randomly generated ID assigned to the field, which can then be used by any JS functions that need it.