### PR TITLE
Provide association name as event attribute

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,7 @@
+master (unreleased)
+
+* Provide association name in all events as `event.association`
+
 0.3.2 (April 5, 2013)
 
 * Render blueprints inside form (thanks taavo)

--- a/vendor/assets/javascripts/jquery_nested_form.js
+++ b/vendor/assets/javascripts/jquery_nested_form.js
@@ -51,8 +51,8 @@
       var field = this.insertFields(content, assoc, link);
       // bubble up event upto document (through form)
       field
-        .trigger({ type: 'nested:fieldAdded', field: field })
-        .trigger({ type: 'nested:fieldAdded:' + assoc, field: field });
+        .trigger({ type: 'nested:fieldAdded', field: field, association: assoc })
+        .trigger({ type: 'nested:fieldAdded:' + assoc, field: field, association: assoc });
       return false;
     },
     newId: function() {
@@ -77,8 +77,8 @@
       field.hide();
       
       field
-        .trigger({ type: 'nested:fieldRemoved', field: field })
-        .trigger({ type: 'nested:fieldRemoved:' + assoc, field: field });
+        .trigger({ type: 'nested:fieldRemoved', field: field, association: assoc  })
+        .trigger({ type: 'nested:fieldRemoved:' + assoc, field: field, association: assoc });
       return false;
     }
   };

--- a/vendor/assets/javascripts/prototype_nested_form.js
+++ b/vendor/assets/javascripts/prototype_nested_form.js
@@ -48,8 +48,8 @@ document.observe('click', function(e, el) {
     } else {
       field = el.insert({ before: content });
     }
-    field.fire('nested:fieldAdded', {field: field});
-    field.fire('nested:fieldAdded:' + assoc, {field: field});
+    field.fire('nested:fieldAdded', {field: field, association: assoc});
+    field.fire('nested:fieldAdded:' + assoc, {field: field, association: assoc});
     return false;
   }
 });
@@ -62,8 +62,8 @@ document.observe('click', function(e, el) {
       hidden_field.value = '1';
     }
     var field = el.up('.fields').hide();
-    field.fire('nested:fieldRemoved', {field: field});
-    field.fire('nested:fieldRemoved:' + assoc, {field: field});
+    field.fire('nested:fieldRemoved', {field: field, association: assoc});
+    field.fire('nested:fieldRemoved:' + assoc, {field: field, association: assoc});
     return false;
   }
 });


### PR DESCRIPTION
This can make to work with script's events easier (in particular when listening to the general `nested:fieldAdded` but still finding the correct `link_to_add` and `link_to_remove`).